### PR TITLE
Remove double airdrop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ let connection = new web3.Connection(web3.clusterApiUrl("devnet"))
 
 async function main() {
     let payer = await initializeKeypair(connection)
-    await connection.requestAirdrop(payer.publicKey, web3.LAMPORTS_PER_SOL * 1)
 
     const transactionSignature = await sayHello(payer)
 

--- a/src/initializeKeypair.ts
+++ b/src/initializeKeypair.ts
@@ -30,10 +30,10 @@ async function airdropSolIfNeeded(
     const balance = await connection.getBalance(signer.publicKey)
     console.log("Current balance is", balance / web3.LAMPORTS_PER_SOL)
     if (balance < web3.LAMPORTS_PER_SOL) {
-        console.log("Airdropping 1 SOL...")
+        console.log("Airdropping 2 SOL...")
         const signature = await connection.requestAirdrop(
             signer.publicKey,
-            web3.LAMPORTS_PER_SOL
+            web3.LAMPORTS_PER_SOL * 2
         )
         await connection.confirmTransaction(signature)
     }


### PR DESCRIPTION
An airdrop is already requested in `initializeKeypair.ts` at line 34. Requesting an airdrop again at `index.ts` may result in an http response error:

`Error: 429 Too Many Requests:  {"jsonrpc":"2.0","error":{"code": 429, "message":"You have requested too many airdrops. Wait 24 hours for a refill."}, "id": "eef447ec-be23-465e-b9e4-7667956bd532" } `

This will cause the program to exit without executing the transaction.

Furthermore,  at the second attempt to execute the transaction, the conditional statement at line 32 in `initializeKeypair.ts` will be `true` and a new airdrop will be requested, which will cause the same http response error mentioned above:

```
Current balance is 0.999995
Airdropping 1 SOL...
Error: 429 [...]
```

 Therefore, I suggest to increase the airdrop amount at line 36 to 2 SOL.